### PR TITLE
Removed a `qemu-user-binfmt` from dependency because it had conflicts with `qemu-user-static`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a repository that contains scripts for compiling an ARM64 UEFI image for
 # Install dependencies
 sudo apt-get install debootstrap mtools parted gnupg systemd-container eatmydata rsync git squashfs-tools
 # Install dependencies, if your builder system is NOT arm64
-sudo apt-get install binfmt-support qemu qemu-user-static qemu-user-binfmt
+sudo apt-get install binfmt-support qemu qemu-user-static
 ```
 
 ### Build everything


### PR DESCRIPTION
I assume this is safe to do as `apt info qemu-user-binfmt` shows the following:

```
This is an empty package, it does not contain any additional files, only
registration scripts which run at install and remove times.
```