### PR TITLE
Fix bug of missing /dev/loop0p1 on slow systems

### DIFF
--- a/scripts/01-setup-efi-img.sh
+++ b/scripts/01-setup-efi-img.sh
@@ -19,10 +19,13 @@ parted -s "${BASE_IMG_FILE}" mklabel gpt
 parted -s "${BASE_IMG_FILE}" mkpart primary fat32 1MiB 100%
 parted -s "${BASE_IMG_FILE}" set 1 esp on
 
+sleep 2
+
 # Create a loop device for the image file
 LOOP_DEV=$(losetup --find --show --partscan "${BASE_IMG_FILE}")
 
+# Fixes bug of /dev/loopp0p1 not found on slow systems
+sleep 5
+
 # Create a filesystem on the loop device
 mkfs.vfat -F32 "${LOOP_DEV}p1"
-
-

--- a/scripts/01-setup-efi-img.sh
+++ b/scripts/01-setup-efi-img.sh
@@ -19,12 +19,13 @@ parted -s "${BASE_IMG_FILE}" mklabel gpt
 parted -s "${BASE_IMG_FILE}" mkpart primary fat32 1MiB 100%
 parted -s "${BASE_IMG_FILE}" set 1 esp on
 
+# Just for caution
 sleep 2
 
 # Create a loop device for the image file
 LOOP_DEV=$(losetup --find --show --partscan "${BASE_IMG_FILE}")
 
-# Fixes bug of /dev/loopp0p1 not found on slow systems
+# Fixes bug of /dev/loop0p1 not found by mkfs on slow systems
 sleep 5
 
 # Create a filesystem on the loop device

--- a/scripts/03-setup-rootfs.sh
+++ b/scripts/03-setup-rootfs.sh
@@ -26,7 +26,6 @@ info "Mounting EFI partition"
 LOOP_DEV=$(losetup --find --show --partscan "${BASE_IMG_FILE}")
 sleep 5
 mount "${LOOP_DEV}p1" "${ROOTFS_BASE_DIR}/boot/efi"
-sleep 5
 
 info "Bind mounting apt cache"
 mkdir -p "${ROOTFS_BASE_DIR}/var/cache/apt/archives"

--- a/scripts/03-setup-rootfs.sh
+++ b/scripts/03-setup-rootfs.sh
@@ -24,7 +24,9 @@ cp -f "${SCRIPTS_DIR}/chroot-base.sh" "${ROOTFS_BASE_DIR}"
 # Mount the EFI system partition
 info "Mounting EFI partition"
 LOOP_DEV=$(losetup --find --show --partscan "${BASE_IMG_FILE}")
+sleep 5
 mount "${LOOP_DEV}p1" "${ROOTFS_BASE_DIR}/boot/efi"
+sleep 5
 
 info "Bind mounting apt cache"
 mkdir -p "${ROOTFS_BASE_DIR}/var/cache/apt/archives"

--- a/scripts/live/04-setup-live-rootfs.sh
+++ b/scripts/live/04-setup-live-rootfs.sh
@@ -31,6 +31,8 @@ rsync -arv "${FS_LIVE_DIR}/" "${ROOTFS_LIVE_DIR}/"
 # Mount the EFI system partition
 info "Mounting EFI partition to /iso"
 LOOP_DEV=$(losetup --find --show --partscan "${LIVE_IMG_FILE}")
+sleep 5
+
 mkdir -p "${ROOTFS_LIVE_DIR}/iso"
 mount "${LOOP_DEV}p1" "${ROOTFS_LIVE_DIR}/iso"
 

--- a/scripts/live/05-setup-pool.sh
+++ b/scripts/live/05-setup-pool.sh
@@ -21,6 +21,8 @@ mkdir -p "${MNT_DIR}"
 
 info "Mounting image"
 LOOP_DEV=$(losetup --find --show --partscan "${LIVE_IMG_FILE}")
+sleep 5
+
 mount "${LOOP_DEV}p1" "${MNT_DIR}"
 
 mkdir -p "${DISTS_DIR}/${UBUNTU_CODE}"

--- a/scripts/live/06-build-live-image.sh
+++ b/scripts/live/06-build-live-image.sh
@@ -21,6 +21,8 @@ mkdir -p "${MNT_DIR}"
 
 info "Mounting image"
 LOOP_DEV=$(losetup --find --show --partscan "${LIVE_IMG_FILE}")
+sleep 5
+
 mount "${LOOP_DEV}p1" "${MNT_DIR}"
 mkdir -p "${CASPER_DIR}"
 


### PR DESCRIPTION
Fixes the bug mentioned in #10 (last comment of mine).
On slow machines, `losetup` returns faster than `/dev/loop` is registered by the kernel. So `mkfs` fails since `/dev/loop` is not yet ready. Can be fixed by simply waiting a few seconds before `mkfs`.